### PR TITLE
TSConfig improvements

### DIFF
--- a/functions/src/migrateToFirestore.ts
+++ b/functions/src/migrateToFirestore.ts
@@ -2,7 +2,7 @@ import firebaseAdmin = require('firebase-admin')
 import { Request, Response } from 'express'
 import firebaseApp = firebaseAdmin.app.App
 
-export const migrateToFirestore = (firebaseApp: firebaseApp) => (request: Request, response: Response) => {
+export const migrateToFirestore = (firebaseApp: firebaseApp) => (_: Request, response: Response) => {
     const firestore = firebaseApp.firestore()
     const designCategory = firestore.collection('categories').doc('xA41e90i2yqopYycx1fm')
     const days = firestore.collection('days')
@@ -130,9 +130,6 @@ export const migrateToFirestore = (firebaseApp: firebaseApp) => (request: Reques
 
 const orNull = (val: any) => val || null
 
-const category = (name: any) => ({
-    name: orNull(name)
-})
 const day = (date: any, position: any) => ({
     date: orNull(date),
     position: orNull(position)
@@ -149,9 +146,7 @@ const event = (
         track: orNull(track),
         type: orNull(type)
     })
-const level = (name: any) => ({
-    name: orNull(name)
-})
+
 const place = (name: any, floor: any) => ({
     name: orNull(name),
     floor: orNull(floor)

--- a/functions/src/schedule-view/generate-schedule.ts
+++ b/functions/src/schedule-view/generate-schedule.ts
@@ -4,7 +4,7 @@ import { Speaker, SchedulePage } from "./schedule-view-data"
 import { DayData, EventData, SubmissionData, PlaceData, TrackData, SpeakerData, UserData, LevelData } from "../firestore/data"
 import { collection as firestoreCollection } from '../firestore/collection'
 
-export const generateSchedule = (firebaseApp: FirebaseApp) => (request: Request, response: Response) => {
+export const generateSchedule = (firebaseApp: FirebaseApp) => (_: Request, response: Response) => {
     const firestore = firebaseApp.firestore()
     const collection = firestoreCollection(firebaseApp)
 

--- a/functions/tsconfig.json
+++ b/functions/tsconfig.json
@@ -6,6 +6,8 @@
             "es6"
         ],
         "strict": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
         "noImplicitReturns": true
     },
     "include": [

--- a/functions/tsconfig.json
+++ b/functions/tsconfig.json
@@ -2,6 +2,9 @@
     "compilerOptions": {
         "module": "commonjs",
         "target": "es6",
+        "lib": [
+            "es6"
+        ],
         "strict": true,
         "noImplicitReturns": true
     },


### PR DESCRIPTION
## Problem

DOM was being included in the global namespace, thus giving false positives on libraries that weren't actually being there (e.g. `fetch` and `document`)

Unused parameters and local vars weren't being flagged.

## Solution

Build will now fail when leaving unused parameters (you can use `_`) to name a parameter to be ignored) and accessing things that aren't available in node.

### Screenshots

![image](https://user-images.githubusercontent.com/1263058/35218022-135707e0-ff65-11e7-8bd1-eee26458ed68.png)
