### PR TITLE
Cleanup

### DIFF
--- a/functions/src/schedule-view/generate-schedule.ts
+++ b/functions/src/schedule-view/generate-schedule.ts
@@ -1,6 +1,6 @@
 import { FirebaseApp } from "../firebase"
 import { Request, Response } from 'express'
-import { Speaker, SchedulePage } from "./schedule-view-data"
+import { Speaker, SchedulePage, Track } from "./schedule-view-data"
 import { DayData, EventData, SubmissionData, PlaceData, TrackData, SpeakerData, UserData, LevelData } from "../firestore/data"
 import { collection as firestoreCollection } from '../firestore/collection'
 
@@ -76,7 +76,7 @@ export const generateSchedule = (firebaseApp: FirebaseApp) => (_: Request, respo
                         startTime: event.start_time,
                         endTime: event.end_time,
                         place: place,
-                        track: track,
+                        track: trackFrom(track),
                         speakers: eventSpeakers,
                         experienceLevel: level,
                         type: event.type,
@@ -90,4 +90,17 @@ export const generateSchedule = (firebaseApp: FirebaseApp) => (_: Request, respo
     }).then(() => {
         response.status(200).send('Yay!')
     })
+}
+
+const trackFrom = (rawTrack: TrackData & { id: string } | null): Track | null => {
+    if (rawTrack === null) {
+        return null
+    }
+    return {
+        id: rawTrack.id,
+        name: rawTrack.name,
+        accentColor: rawTrack.accent_color,
+        textColor: rawTrack.text_color,
+        iconUrl: rawTrack.icon_url
+    }
 }

--- a/functions/src/schedule-view/schedule-view-data.ts
+++ b/functions/src/schedule-view/schedule-view-data.ts
@@ -36,9 +36,9 @@ export interface Place {
 export interface Track {
     id: string
     name: string
-    accent_color: Optional<string>
-    text_color: Optional<string>
-    icon_url: Optional<string>
+    accentColor: Optional<string>
+    textColor: Optional<string>
+    iconUrl: Optional<string>
 }
 
 export interface Speaker {

--- a/functions/src/twitter/fetch-twitter.ts
+++ b/functions/src/twitter/fetch-twitter.ts
@@ -1,10 +1,8 @@
-import { Request, Response, json } from 'express'
-import { Buffer } from "buffer";
-import { FirebaseApp, Firestore, DocumentReference } from "../firebase";
+import { Request, Response } from 'express'
+import { FirebaseApp, Firestore } from "../firebase";
 import { Fetch } from "../fetch";
 import { base64_encode } from '../base64';
 import { Tweet, User, HashtagsEntity, MediaEntity, UrlsEntity, UserMention } from './twitter-data';
-import { collection as firestoreCollection } from '../firestore/collection'
 import { FirestoreTweet, FirestoreUser, FirestoreHashtag, FirestoreMedia, FirestoreUrl, FirestoreUserMention } from './firestore-data';
 import { present, Optional } from '../optional';
 import { WriteResult } from '@google-cloud/firestore';
@@ -15,7 +13,7 @@ export const fetchTwitter = (
     firebaseApp: FirebaseApp,
     fetch: Fetch,
     { consumer_key, consumer_secret, search_query }: TwitterConfig
-) => (request: Request, response: Response) => {
+) => (_: Request, response: Response) => {
     const authenticateTwitter = (consumerKey: string, consumerSecret: string): Promise<string> => {
         const auth = base64_encode(`${encodeURIComponent(consumerKey)}:${encodeURIComponent(consumerSecret)}`)
         return fetch('https://api.twitter.com/oauth2/token', {


### PR DESCRIPTION
## Problem

There's some outstanding Lint warnings on the code; we also want to get rid of some sketchy variable names on the Android side to map to the Firestore track data, so those snake case fields should be renamed to camel case.

## Solution

Address all ESLint warnings (mostly imports); rename the fields for `TrackData` that are in snake_case to camelCase (a corresponding PR will be opened on squanchy-android)

### Test(s) added 

No tests — yet!

### Paired with 

Nobody
