### PR TITLE
Speaker view

### DIFF
--- a/functions/src/firestore/collection.ts
+++ b/functions/src/firestore/collection.ts
@@ -1,6 +1,6 @@
 import { FirebaseApp } from "../firebase"
 
-export const collection = (firebaseApp: FirebaseApp) => <T>(collection: string): Promise<WithId<T>[]> => {
+export const firestoreCollection = (firebaseApp: FirebaseApp) => <T>(collection: string): Promise<WithId<T>[]> => {
     return firebaseApp.firestore().collection(collection)
         .get()
         .then(value => {

--- a/functions/src/main.ts
+++ b/functions/src/main.ts
@@ -4,6 +4,7 @@ import { migrateToFirestore } from './migrateToFirestore'
 import { generateSchedule } from './schedule-view/generate-schedule'
 import { fetchTwitter } from './twitter/fetch-twitter';
 import fetch from "node-fetch";
+import { generateSpeakers } from './speakers-view/generate-speakers';
 
 const firebaseConf = config().firebase
 const firebaseApp = initializeApp(firebaseConf)
@@ -11,5 +12,6 @@ const firebaseApp = initializeApp(firebaseConf)
 export = {
     migrateToFirestore: https.onRequest(migrateToFirestore(firebaseApp)),
     generateSchedule: https.onRequest(generateSchedule(firebaseApp)),
-    fetchTwitter: https.onRequest(fetchTwitter(firebaseApp, fetch, config().twitter))
+    generateSpeakers: https.onRequest(generateSpeakers(firebaseApp)),
+    fetchTwitter: https.onRequest(fetchTwitter(firebaseApp, fetch, config().twitter)),
 }

--- a/functions/src/schedule-view/generate-schedule.ts
+++ b/functions/src/schedule-view/generate-schedule.ts
@@ -2,7 +2,7 @@ import { FirebaseApp } from "../firebase"
 import { Request, Response } from 'express'
 import { Speaker, SchedulePage, Track } from "./schedule-view-data"
 import { DayData, EventData, SubmissionData, PlaceData, TrackData, SpeakerData, UserData, LevelData } from "../firestore/data"
-import { collection as firestoreCollection, WithId } from '../firestore/collection'
+import { firestoreCollection, WithId } from '../firestore/collection'
 
 export const generateSchedule = (firebaseApp: FirebaseApp) => (_: Request, response: Response) => {
     const firestore = firebaseApp.firestore()

--- a/functions/src/speakers-view/generate-speakers.ts
+++ b/functions/src/speakers-view/generate-speakers.ts
@@ -1,0 +1,49 @@
+import { FirebaseApp } from "../firebase"
+import { Request, Response } from 'express'
+import { firestoreCollection, WithId } from "../firestore/collection"
+import { SpeakerData, UserData } from "../firestore/data"
+import { SpeakerPage } from "./speakers-view-data"
+
+export const generateSpeakers = (firebaseApp: FirebaseApp) => (_: Request, response: Response) => {
+    const firestore = firebaseApp.firestore()
+    const collection = firestoreCollection(firebaseApp)
+
+    const speakers = collection<SpeakerData>('speakers')
+    const users = collection<UserData>('user_profiles')
+
+    Promise.all([
+        speakers,
+        users
+    ])
+        .then(([speakers, users]) => {
+            const speakerPages = firestore.collection('views')
+                .doc('speakers')
+                .collection('speaker_pages')
+
+            return Promise.all(speakers.map(asSpeakerPage(users)).map(speakerPage => {
+                return speakerPages.doc(speakerPage.id).set(speakerPage)
+            }))
+        })
+        .then(() => {
+            response.status(200).send('Yay!')
+        })
+        .catch(error => {
+            console.error(error)
+            response.status(500).send('Whoops! Something went wrong.')
+        })
+}
+
+const asSpeakerPage = (users: WithId<UserData>[]) => (speaker: SpeakerData): SpeakerPage => {
+    const user = users.find(user => user.id === speaker.user_profile.id)!
+
+    return {
+        id: user.id,
+        name: user.full_name,
+        bio: speaker.bio,
+        companyName: speaker.company_name || null,
+        companyUrl: speaker.company_url || null,
+        personalUrl: speaker.personal_url || null,
+        photoUrl: user.profile_pic || null,
+        twitterUsername: speaker.twitter_handle || null
+    }
+}

--- a/functions/src/speakers-view/speakers-view-data.ts
+++ b/functions/src/speakers-view/speakers-view-data.ts
@@ -1,0 +1,12 @@
+import { Optional } from "../optional";
+
+export interface SpeakerPage {
+    readonly id: string
+    readonly name: string
+    readonly bio: string
+    readonly companyName: Optional<string>
+    readonly companyUrl: Optional<string>
+    readonly personalUrl: Optional<string>
+    readonly photoUrl: Optional<string>
+    readonly twitterUsername: Optional<string>
+}


### PR DESCRIPTION
## Problem

We need a view for the speakers as part of #8 

![image](https://user-images.githubusercontent.com/1263058/35592639-8d2e699a-0605-11e8-8780-d393cfdf899f.png)

## Solution

This was pretty easy but made me realise we have a ticking bomb in our codebase:

Firestore will accept only `null` for a optional field when **writing**, but will return `undefined` when **reading** that field.

That means that our `*Data` interfaces are accurate during **writes** since their optional fields are `T | null` but can't safely be used as reading interfaces, because they won't alarm us of potential `undefined` fields and thus the compiler won't complain about potentially wrong data.

For this the only solution I envision on the long run is to **not** have the same interface for reading and writing data, as what we get and what we set is fundamentally different. Opinions and/or suggestions on this are greatly welcome, but I'd create an issue to deal with it, it's out of scope here.

## Tests

The code was particularly simple (there are only 2 entities, no transformations), didn't really feel the need to add tests on this, as the mocking bit would be much more than the actual testing.

The only thing that _should_ be tested is the `|| null` bit in `asSpeakerPage`, only that is because in reality what we have at runtime is a `T | undefined`, and right now passing an undefined in those fields would make the compilation fail (it's expecting a nullable field), once we sort out our interfaces, this should be compile-time safe though.