### PR TITLE
Disallow global write

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,7 +1,7 @@
 service cloud.firestore {
   match /databases/{database}/documents {
     match /{document=**} {
-      allow read, write;
+      allow read;
     }
   }
 }


### PR DESCRIPTION
## Problem

We need to disallow global writeability for firestore db.

## Solution

Updated the rules file.