### PR TITLE
Use event name as prefix for Algolia indices

### DIFF
--- a/functions/src/patch/patch.ts
+++ b/functions/src/patch/patch.ts
@@ -3,10 +3,10 @@ import { FirebaseApp } from '../firebase'
 import { mapFields } from './map-fields'
 import { mapObject } from '../objects'
 import { squanchyValidators } from './squanchy-validators'
-import { isNotEmpty } from '../strings'
+import { ensureNotEmpty } from '../strings'
 
 const patch = (firebaseApp: FirebaseApp, config: PatchConfig) => {
-    isNotEmpty(config.vendor_name, 'config.vendor_name')
+    ensureNotEmpty(config.vendor_name, 'config.vendor_name')
 
     const expressApp = express()
 

--- a/functions/src/search/config.ts
+++ b/functions/src/search/config.ts
@@ -1,4 +1,5 @@
 export interface AlgoliaConfig {
     application_id: string
     api_key: string
+    index_prefix: string
 }

--- a/functions/src/search/index-contents.ts
+++ b/functions/src/search/index-contents.ts
@@ -13,7 +13,7 @@ export const indexContent =
             algoliaConfig.api_key
         )
 
-        const indexPrefix = algoliaConfig.index_prefix.replace(/[^\w]/, '_')
+        const indexPrefix = replaceNonWordCharsWithUnderscores(algoliaConfig.index_prefix)
         Promise.all([
             indexSpeakers(firebaseApp, algolia, indexPrefix),
             indexEvents(firebaseApp, algolia, indexPrefix)
@@ -26,5 +26,5 @@ export const indexContent =
     }
 
 const replaceNonWordCharsWithUnderscores = (original: string): string => {
-    original.replace(/[^\w]/, '_')
+    return original.replace(/[^\w]/, '_')
 }

--- a/functions/src/search/index-contents.ts
+++ b/functions/src/search/index-contents.ts
@@ -13,9 +13,10 @@ export const indexContent =
             algoliaConfig.api_key
         )
 
+        const indexPrefix = algoliaConfig.index_prefix.replace(/[^\w]/, '_')
         Promise.all([
-            indexSpeakers(firebaseApp, algolia),
-            indexEvents(firebaseApp, algolia)
+            indexSpeakers(firebaseApp, algolia, indexPrefix),
+            indexEvents(firebaseApp, algolia, indexPrefix)
         ]).then(() => {
             response.status(200).send('Yay!')
         }).catch(error => {
@@ -23,3 +24,7 @@ export const indexContent =
             response.status(500).send('Nay!')
         })
     }
+
+const replaceNonWordCharsWithUnderscores = (original: string): string => {
+    original.replace(/[^\w]/, '_')
+}

--- a/functions/src/search/index-contents.ts
+++ b/functions/src/search/index-contents.ts
@@ -5,6 +5,7 @@ import { FirebaseApp } from '../firebase'
 import { AlgoliaConfig } from './config'
 import { indexEvents } from './index-events'
 import { indexSpeakers } from './index-speakers'
+import { replaceNonWordCharsWithUnderscores, ensureNotEmpty } from '../strings'
 
 export const indexContent =
     (firebaseApp: FirebaseApp, algoliaConfig: AlgoliaConfig) => (_: Request, response: Response) => {
@@ -13,6 +14,7 @@ export const indexContent =
             algoliaConfig.api_key
         )
 
+        ensureNotEmpty(algoliaConfig.index_prefix, 'algoliaConfig.index_prefix')
         const indexPrefix = replaceNonWordCharsWithUnderscores(algoliaConfig.index_prefix)
         Promise.all([
             indexSpeakers(firebaseApp, algolia, indexPrefix),
@@ -24,7 +26,3 @@ export const indexContent =
             response.status(500).send('Nay!')
         })
     }
-
-const replaceNonWordCharsWithUnderscores = (original: string): string => {
-    return original.replace(/[^\w]/, '_')
-}

--- a/functions/src/search/index-events.ts
+++ b/functions/src/search/index-events.ts
@@ -5,8 +5,8 @@ import { firestoreCollection, WithId } from '../firestore/collection'
 import { EventData, SubmissionData } from '../firestore/data'
 import { EventRecord } from './records'
 
-export const indexEvents = (firebaseApp: FirebaseApp, algolia: AlgoliaClient): Promise<void> => {
-    const eventsIndex = algolia.initIndex('events')
+export const indexEvents = (firebaseApp: FirebaseApp, algolia: AlgoliaClient, indexPrefix: string): Promise<void> => {
+    const eventsIndex = algolia.initIndex(`${indexPrefix}_events`)
 
     const collection = firestoreCollection(firebaseApp)
 

--- a/functions/src/search/index-speakers.ts
+++ b/functions/src/search/index-speakers.ts
@@ -5,9 +5,10 @@ import { firestoreCollection, WithId } from '../firestore/collection'
 import { SpeakerData, UserData } from '../firestore/data'
 import { SpeakerRecord } from './records'
 
-export const indexSpeakers = (firebaseApp: FirebaseApp, algolia: AlgoliaClient): Promise<void> => {
+export const indexSpeakers = (firebaseApp: FirebaseApp, algolia: AlgoliaClient, indexPrefix: string): Promise<void> => {
+    const speakersIndex = algolia.initIndex(`${indexPrefix}_speakers`)
+
     const collection = firestoreCollection(firebaseApp)
-    const speakersIndex = algolia.initIndex('speakers')
 
     const speakersPromise = collection<SpeakerData>('speakers')
     const userProfilesPromise = collection<UserData>('user_profiles')

--- a/functions/src/strings.ts
+++ b/functions/src/strings.ts
@@ -1,5 +1,9 @@
-export const isNotEmpty = (text: string, name: string) => {
+export const ensureNotEmpty = (text: string, name: string) => {
     if (text.trim.length === 0) {
         throw new Error(`The provided string ${name} was empty but it must be non empty`)
     }
+}
+
+export const replaceNonWordCharsWithUnderscores = (original: string): string => {
+    return original.replace(/[^\w]/, '_')
 }


### PR DESCRIPTION
## Problem

Our indices on Algolia are all on the same project, so we cannot currently host more than one conference there.

## Solution

As their support suggested, we should prefix our indices with a unique conference name, to allow hosting multiple conferences on the same Algolia instance.

The conference name comes from the Firebase Functions environment configurations.

### Test(s) added 

Nope

### Paired with 

Nobody