### PR TITLE
Make Patch write to raw_data/syx

### DIFF
--- a/functions/src/event-details-view/generate-event-details.ts
+++ b/functions/src/event-details-view/generate-event-details.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from 'express'
 import { FirebaseApp } from '../firebase'
-import { firestoreCollection, WithId } from '../firestore/collection'
+import { firestoreRawCollection, WithId } from '../firestore/collection'
 import {
     EventData,
     LevelData,
@@ -15,15 +15,15 @@ import { map } from '../optional'
 
 export const generateEventDetails = (firebaseApp: FirebaseApp) => (_: Request, response: Response) => {
     const firestore = firebaseApp.firestore()
-    const collection = firestoreCollection(firebaseApp)
+    const rawCollection = firestoreRawCollection(firebaseApp)
 
-    const eventsPromise = collection<EventData>('events')
-    const submissionsPromise = collection<SubmissionData>('submissions')
-    const placesPromise = collection<PlaceData>('places')
-    const tracksPromise = collection<TrackData>('tracks')
-    const speakersPromise = collection<SpeakerData>('speakers')
-    const usersPromise = collection<UserData>('user_profiles')
-    const levelsPromise = collection<LevelData>('levels')
+    const eventsPromise = rawCollection<EventData>('events')
+    const submissionsPromise = rawCollection<SubmissionData>('submissions')
+    const placesPromise = rawCollection<PlaceData>('places')
+    const tracksPromise = rawCollection<TrackData>('tracks')
+    const speakersPromise = rawCollection<SpeakerData>('speakers')
+    const usersPromise = rawCollection<UserData>('user_profiles')
+    const levelsPromise = rawCollection<LevelData>('levels')
 
     Promise.all([
         eventsPromise,

--- a/functions/src/firestore/collection.ts
+++ b/functions/src/firestore/collection.ts
@@ -1,7 +1,7 @@
 import { FirebaseApp } from '../firebase'
 
-export const firestoreCollection = (firebaseApp: FirebaseApp) => <T>(collection: string): Promise<WithId<T>[]> => {
-    return firebaseApp.firestore().collection(collection)
+export const firestoreRawCollection = (firebaseApp: FirebaseApp) => <T>(collection: string): Promise<WithId<T>[]> => {
+    return firebaseApp.firestore().collection('raw_data').doc('syx').collection(collection)
         .get()
         .then(value => {
             return value.docs.map(doc => withId(doc.data() as T, doc.id))

--- a/functions/src/patch/config.ts
+++ b/functions/src/patch/config.ts
@@ -1,3 +1,4 @@
 interface PatchConfig {
-    app_token: string
+    app_token: string,
+    vendor_name: string
 }

--- a/functions/src/patch/patch.ts
+++ b/functions/src/patch/patch.ts
@@ -62,7 +62,7 @@ const patch = (firebaseApp: FirebaseApp, config: PatchConfig) => {
         }
 
         const firestore = firebaseApp.firestore()
-        firestore.collection(collection).doc(id)
+        firestore.collection('raw_data').doc('syx').collection(collection).doc(id)
             .set(body)
             .then(() => {
                 res.status(200).send()

--- a/functions/src/patch/patch.ts
+++ b/functions/src/patch/patch.ts
@@ -3,8 +3,11 @@ import { FirebaseApp } from '../firebase'
 import { mapFields } from './map-fields'
 import { mapObject } from '../objects'
 import { squanchyValidators } from './squanchy-validators'
+import { isNotEmpty } from '../strings'
 
 const patch = (firebaseApp: FirebaseApp, config: PatchConfig) => {
+    isNotEmpty(config.vendor_name, 'config.vendor_name')
+
     const expressApp = express()
 
     expressApp.use((req, res, next) => {
@@ -62,7 +65,7 @@ const patch = (firebaseApp: FirebaseApp, config: PatchConfig) => {
         }
 
         const firestore = firebaseApp.firestore()
-        firestore.collection('raw_data').doc('syx').collection(collection).doc(id)
+        firestore.collection('raw_data').doc(config.vendor_name).collection(collection).doc(id)
             .set(body)
             .then(() => {
                 res.status(200).send()

--- a/functions/src/schedule-view/generate-schedule.ts
+++ b/functions/src/schedule-view/generate-schedule.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from 'express'
 import { FirebaseApp } from '../firebase'
-import { firestoreCollection, WithId } from '../firestore/collection'
+import { firestoreRawCollection, WithId } from '../firestore/collection'
 import {
     DayData,
     EventData,
@@ -16,16 +16,16 @@ import { map } from '../optional'
 
 export const generateSchedule = (firebaseApp: FirebaseApp) => (_: Request, response: Response) => {
     const firestore = firebaseApp.firestore()
-    const collection = firestoreCollection(firebaseApp)
+    const rawCollection = firestoreRawCollection(firebaseApp)
 
-    const daysPromise = collection<DayData>('days')
-    const eventsPromise = collection<EventData>('events')
-    const submissionsPromise = collection<SubmissionData>('submissions')
-    const placesPromise = collection<PlaceData>('places')
-    const tracksPromise = collection<TrackData>('tracks')
-    const speakersPromise = collection<SpeakerData>('speakers')
-    const usersPromise = collection<UserData>('user_profiles')
-    const levelsPromise = collection<LevelData>('levels')
+    const daysPromise = rawCollection<DayData>('days')
+    const eventsPromise = rawCollection<EventData>('events')
+    const submissionsPromise = rawCollection<SubmissionData>('submissions')
+    const placesPromise = rawCollection<PlaceData>('places')
+    const tracksPromise = rawCollection<TrackData>('tracks')
+    const speakersPromise = rawCollection<SpeakerData>('speakers')
+    const usersPromise = rawCollection<UserData>('user_profiles')
+    const levelsPromise = rawCollection<LevelData>('levels')
 
     Promise.all([
         daysPromise,

--- a/functions/src/search/index-events.ts
+++ b/functions/src/search/index-events.ts
@@ -1,17 +1,17 @@
 import { AlgoliaClient } from 'algoliasearch'
 import { FirebaseApp } from '../firebase'
 
-import { firestoreCollection, WithId } from '../firestore/collection'
+import { firestoreRawCollection, WithId } from '../firestore/collection'
 import { EventData, SubmissionData } from '../firestore/data'
 import { EventRecord } from './records'
 
 export const indexEvents = (firebaseApp: FirebaseApp, algolia: AlgoliaClient): Promise<void> => {
     const eventsIndex = algolia.initIndex('events')
 
-    const collection = firestoreCollection(firebaseApp)
+    const rawCollection = firestoreRawCollection(firebaseApp)
 
-    const eventsPromise = collection<EventData>('events')
-    const submissionsPromise = collection<SubmissionData>('submissions')
+    const eventsPromise = rawCollection<EventData>('events')
+    const submissionsPromise = rawCollection<SubmissionData>('submissions')
 
     return Promise.all([
         eventsPromise,

--- a/functions/src/search/index-speakers.ts
+++ b/functions/src/search/index-speakers.ts
@@ -1,16 +1,16 @@
 import { AlgoliaClient } from 'algoliasearch'
 import { FirebaseApp } from '../firebase'
 
-import { firestoreCollection, WithId } from '../firestore/collection'
+import { firestoreRawCollection, WithId } from '../firestore/collection'
 import { SpeakerData, UserData } from '../firestore/data'
 import { SpeakerRecord } from './records'
 
 export const indexSpeakers = (firebaseApp: FirebaseApp, algolia: AlgoliaClient): Promise<void> => {
-    const collection = firestoreCollection(firebaseApp)
+    const rawCollection = firestoreRawCollection(firebaseApp)
     const speakersIndex = algolia.initIndex('speakers')
 
-    const speakersPromise = collection<SpeakerData>('speakers')
-    const userProfilesPromise = collection<UserData>('user_profiles')
+    const speakersPromise = rawCollection<SpeakerData>('speakers')
+    const userProfilesPromise = rawCollection<UserData>('user_profiles')
 
     return Promise.all([speakersPromise, userProfilesPromise])
         .then(([speakers, userProfiles]) => toSpeakerRecords(speakers, userProfiles))

--- a/functions/src/speakers-view/generate-speakers.ts
+++ b/functions/src/speakers-view/generate-speakers.ts
@@ -1,16 +1,16 @@
 import { Request, Response } from 'express'
 
 import { FirebaseApp } from '../firebase'
-import { firestoreCollection, WithId } from '../firestore/collection'
+import { firestoreRawCollection, WithId } from '../firestore/collection'
 import { SpeakerData, UserData } from '../firestore/data'
 import { SpeakerPage } from './speakers-view-data'
 
 export const generateSpeakers = (firebaseApp: FirebaseApp) => (_: Request, response: Response) => {
     const firestore = firebaseApp.firestore()
-    const collection = firestoreCollection(firebaseApp)
+    const rawCollection = firestoreRawCollection(firebaseApp)
 
-    const speakersPromise = collection<SpeakerData>('speakers')
-    const usersPromise = collection<UserData>('user_profiles')
+    const speakersPromise = rawCollection<SpeakerData>('speakers')
+    const usersPromise = rawCollection<UserData>('user_profiles')
 
     Promise.all([
         speakersPromise,

--- a/functions/src/strings.ts
+++ b/functions/src/strings.ts
@@ -1,0 +1,5 @@
+export const isNotEmpty = (text: string, name: string) => {
+    if (text.trim.length === 0) {
+        throw new Error(`The provided string ${name} was empty but it must be non empty`)
+    }
+}

--- a/functions/src/tracks-view/generate-tracks.ts
+++ b/functions/src/tracks-view/generate-tracks.ts
@@ -1,14 +1,14 @@
 import { Request, Response } from 'express'
 import { FirebaseApp } from '../firebase'
-import { firestoreCollection } from '../firestore/collection'
+import { firestoreRawCollection } from '../firestore/collection'
 import { TrackData } from '../firestore/data'
 import { Track } from './tracks-view-data'
 
 export const generateTracks = (firebaseApp: FirebaseApp) => (_: Request, response: Response) => {
     const firestore = firebaseApp.firestore()
-    const collection = firestoreCollection(firebaseApp)
+    const rawCollection = firestoreRawCollection(firebaseApp)
 
-    const tracksPromise = collection<TrackData>('tracks')
+    const tracksPromise = rawCollection<TrackData>('tracks')
 
     tracksPromise.then(tracks => {
         const tracksCollection = firestore.collection('views')


### PR DESCRIPTION
## Problem

Currently all our raw models we receive via `patch` are dumped on the root of the DB. We should move them into a subcollection to tidy things up and allow for later expansion.

## Solution

Make the `patch` call, and all the other functions that read from that data, work out of the `/raw_data/syx` document. So for example `/events` will be moved to `/raw_data/syx/events` etc.

### Test(s) added 

No, this is untested. I'd like @fourlastor to take a look at it.

### Paired with 

Nobody