### PR TITLE
Add badges to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Squanchy
+# Squanchy Firebase
+[![Master CI](https://img.shields.io/circleci/project/github/squanchy-dev/squanchy-firebase/master.svg?style=for-the-badge)](https://circleci.com/gh/squanchy-dev/squanchy-firebase/tree/master) [![Apache 2 license](https://img.shields.io/github/license/squanchy-dev/squanchy-firebase.svg?style=for-the-badge)](https://github.com/squanchy-dev/squanchy-firebase/blob/master/LICENSE)
+
 Squanchy is an open source schedule platform for conferences.
 
 This repository contains all the code you need to set up the Firebase backend for your conference.


### PR DESCRIPTION
## Problem

We don't have badges on the readme and have no visibility over `master` build state

## Solution

Add them

### Test(s) added 

No

### Screenshots

![image](https://user-images.githubusercontent.com/153802/37202939-01ccb3ec-2384-11e8-8823-8a1d7a4f9825.png)

### Paired with 

Nobody