### PR TITLE
Fix required validator

### DIFF
--- a/functions/src/__tests__/patch/validators.ts
+++ b/functions/src/__tests__/patch/validators.ts
@@ -1,0 +1,25 @@
+import { required, failure, success } from '../../patch/validator'
+
+describe('validators', () => {
+    describe('required', () => {
+        it('failure on undefined values', () => {
+            const result = required(undefined)
+            expect(result).toEqual(failure('Required'))
+        })
+
+        it('failure on null values', () => {
+            const result = required(null)
+            expect(result).toEqual(failure('Required'))
+        })
+
+        it('success on falsy values', () => {
+            const result = required(0)
+            expect(result).toEqual(success())
+        })
+
+        it('success on truthy values', () => {
+            const result = required('Hello world!')
+            expect(result).toEqual(success())
+        })
+    })
+})

--- a/functions/src/patch/validator.ts
+++ b/functions/src/patch/validator.ts
@@ -27,7 +27,7 @@ const validateOptional = <T>(predicate: Predicate<T>, failureMessage: string) =>
     return validate<T>(it => (it === undefined || it === null) || predicate(it), failureMessage)
 }
 
-export const required = validate<any>(it => it, 'Required')
+export const required = validate<any>(it => it !== null && it !== undefined, 'Required')
 export const isString = validateOptional<any>(it => typeof(it) === 'string', 'String')
 export const isDate = validateOptional<any>(it => it instanceof Date, 'Date')
 export const isInteger = validateOptional<any>(it => Number.isInteger(it), 'Integer')


### PR DESCRIPTION
## Problem

The required validator was checking for truthyness of the value instead of checking explicitly for undefined and null. That led to a bug where `0` would fail that test (as empty string and so on).

## Solution

Make the check explicit.