### PR TITLE
Use vendor name in firestoreRawCollection

### DIFF
--- a/functions/src/event-details-view/generate-event-details.ts
+++ b/functions/src/event-details-view/generate-event-details.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from 'express'
 import { FirebaseApp } from '../firebase'
-import { firestoreRawCollection, WithId } from '../firestore/collection'
+import { WithId, RawCollection } from '../firestore/collection'
 import {
     EventData,
     LevelData,
@@ -13,10 +13,10 @@ import {
 import { Event, Speaker, Track } from './event-details-view-data'
 import { map } from '../optional'
 
-export const generateEventDetails = (firebaseApp: FirebaseApp) => (_: Request, response: Response) => {
+export const generateEventDetails = (
+    firebaseApp: FirebaseApp, rawCollection: RawCollection
+) => (_: Request, response: Response) => {
     const firestore = firebaseApp.firestore()
-    const rawCollection = firestoreRawCollection(firebaseApp)
-
     const eventsPromise = rawCollection<EventData>('events')
     const submissionsPromise = rawCollection<SubmissionData>('submissions')
     const placesPromise = rawCollection<PlaceData>('places')

--- a/functions/src/firestore/collection.ts
+++ b/functions/src/firestore/collection.ts
@@ -1,12 +1,15 @@
 import { FirebaseApp } from '../firebase'
 
-export const firestoreRawCollection = (firebaseApp: FirebaseApp) => <T>(collection: string): Promise<WithId<T>[]> => {
-    return firebaseApp.firestore().collection('raw_data').doc('syx').collection(collection)
-        .get()
-        .then(value => {
-            return value.docs.map(doc => withId(doc.data() as T, doc.id))
-        })
-}
+export const firestoreRawCollection =
+    (vendorName: string, firebaseApp: FirebaseApp) => <T>(collection: string): Promise<WithId<T>[]> => {
+        return firebaseApp.firestore().collection('raw_data').doc(vendorName).collection(collection)
+            .get()
+            .then(value => {
+                return value.docs.map(doc => withId(doc.data() as T, doc.id))
+            })
+    }
+
+export type RawCollection = <T>(collection: string) => Promise<WithId<T>[]>
 
 export type WithId<T> = T & { id: string }
 const withId = <T>(data: T, id: string): WithId<T> => ({ ...data as any, id })

--- a/functions/src/main.ts
+++ b/functions/src/main.ts
@@ -10,6 +10,7 @@ import { indexContent } from './search/index-contents'
 import { generateSpeakers } from './speakers-view/generate-speakers'
 import { generateTracks } from './tracks-view/generate-tracks'
 import { fetchTwitter } from './twitter/fetch-twitter'
+import { firestoreRawCollection } from './firestore/collection'
 
 const {
     algolia: algoliaConf,
@@ -19,14 +20,15 @@ const {
 } = config()
 
 const firebaseApp = initializeApp(firebaseConf)
+const rawCollection = firestoreRawCollection(patchConf.vendor_name, firebaseApp)
 
 export = {
     fetchTwitter: https.onRequest(fetchTwitter(firebaseApp, fetch, twitterConf)),
-    generateEventDetails: https.onRequest(generateEventDetails(firebaseApp)),
-    generateSchedule: https.onRequest(generateSchedule(firebaseApp)),
-    generateSpeakers: https.onRequest(generateSpeakers(firebaseApp)),
-    generateTracks: https.onRequest(generateTracks(firebaseApp)),
-    indexContent: https.onRequest(indexContent(firebaseApp, algoliaConf)),
+    generateEventDetails: https.onRequest(generateEventDetails(firebaseApp, rawCollection)),
+    generateSchedule: https.onRequest(generateSchedule(firebaseApp, rawCollection)),
+    generateSpeakers: https.onRequest(generateSpeakers(firebaseApp, rawCollection)),
+    generateTracks: https.onRequest(generateTracks(firebaseApp, rawCollection)),
+    indexContent: https.onRequest(indexContent(rawCollection, algoliaConf)),
     migrateToFirestore: https.onRequest(migrateToFirestore(firebaseApp)),
     patch: https.onRequest(patch(firebaseApp, patchConf)),
 }

--- a/functions/src/schedule-view/generate-schedule.ts
+++ b/functions/src/schedule-view/generate-schedule.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from 'express'
 import { FirebaseApp } from '../firebase'
-import { firestoreRawCollection, WithId } from '../firestore/collection'
+import { WithId, RawCollection } from '../firestore/collection'
 import {
     DayData,
     EventData,
@@ -14,9 +14,11 @@ import {
 import { SchedulePage, Speaker, Track } from './schedule-view-data'
 import { map } from '../optional'
 
-export const generateSchedule = (firebaseApp: FirebaseApp) => (_: Request, response: Response) => {
+export const generateSchedule = (
+    firebaseApp: FirebaseApp,
+    rawCollection: RawCollection
+) => (_: Request, response: Response) => {
     const firestore = firebaseApp.firestore()
-    const rawCollection = firestoreRawCollection(firebaseApp)
 
     const daysPromise = rawCollection<DayData>('days')
     const eventsPromise = rawCollection<EventData>('events')

--- a/functions/src/search/index-contents.ts
+++ b/functions/src/search/index-contents.ts
@@ -1,14 +1,14 @@
 import * as algoliasearch from 'algoliasearch'
 import { Request, Response } from 'express'
 
-import { FirebaseApp } from '../firebase'
 import { AlgoliaConfig } from './config'
 import { indexEvents } from './index-events'
 import { indexSpeakers } from './index-speakers'
 import { replaceNonWordCharsWithUnderscores, ensureNotEmpty } from '../strings'
+import { RawCollection } from '../firestore/collection'
 
 export const indexContent =
-    (firebaseApp: FirebaseApp, algoliaConfig: AlgoliaConfig) => (_: Request, response: Response) => {
+    (rawCollection: RawCollection, algoliaConfig: AlgoliaConfig) => (_: Request, response: Response) => {
         const algolia = algoliasearch(
             algoliaConfig.application_id,
             algoliaConfig.api_key
@@ -17,8 +17,8 @@ export const indexContent =
         ensureNotEmpty(algoliaConfig.index_prefix, 'algoliaConfig.index_prefix')
         const indexPrefix = `${replaceNonWordCharsWithUnderscores(algoliaConfig.index_prefix)}-`
         Promise.all([
-            indexSpeakers(firebaseApp, algolia, indexPrefix),
-            indexEvents(firebaseApp, algolia, indexPrefix)
+            indexSpeakers(rawCollection, algolia, indexPrefix),
+            indexEvents(rawCollection, algolia, indexPrefix)
         ]).then(() => {
             response.status(200).send('Yay!')
         }).catch(error => {

--- a/functions/src/search/index-events.ts
+++ b/functions/src/search/index-events.ts
@@ -1,14 +1,15 @@
 import { AlgoliaClient } from 'algoliasearch'
-import { FirebaseApp } from '../firebase'
 
-import { firestoreRawCollection, WithId } from '../firestore/collection'
+import { WithId, RawCollection } from '../firestore/collection'
 import { EventData, SubmissionData } from '../firestore/data'
 import { EventRecord } from './records'
 
-export const indexEvents = (firebaseApp: FirebaseApp, algolia: AlgoliaClient, indexPrefix: string): Promise<void> => {
+export const indexEvents = (
+    rawCollection: RawCollection,
+    algolia: AlgoliaClient,
+    indexPrefix: string
+): Promise<void> => {
     const eventsIndex = algolia.initIndex(`${indexPrefix}_events`)
-
-    const rawCollection = firestoreRawCollection(firebaseApp)
 
     const eventsPromise = rawCollection<EventData>('events')
     const submissionsPromise = rawCollection<SubmissionData>('submissions')

--- a/functions/src/search/index-speakers.ts
+++ b/functions/src/search/index-speakers.ts
@@ -1,14 +1,15 @@
 import { AlgoliaClient } from 'algoliasearch'
-import { FirebaseApp } from '../firebase'
 
-import { firestoreRawCollection, WithId } from '../firestore/collection'
+import { WithId, RawCollection } from '../firestore/collection'
 import { SpeakerData, UserData } from '../firestore/data'
 import { SpeakerRecord } from './records'
 
-export const indexSpeakers = (firebaseApp: FirebaseApp, algolia: AlgoliaClient, indexPrefix: string): Promise<void> => {
+export const indexSpeakers = (
+    rawCollection: RawCollection,
+    algolia: AlgoliaClient,
+    indexPrefix: string
+): Promise<void> => {
     const speakersIndex = algolia.initIndex(`${indexPrefix}_speakers`)
-
-    const rawCollection = firestoreRawCollection(firebaseApp)
 
     const speakersPromise = rawCollection<SpeakerData>('speakers')
     const userProfilesPromise = rawCollection<UserData>('user_profiles')

--- a/functions/src/speakers-view/generate-speakers.ts
+++ b/functions/src/speakers-view/generate-speakers.ts
@@ -1,13 +1,15 @@
 import { Request, Response } from 'express'
 
 import { FirebaseApp } from '../firebase'
-import { firestoreRawCollection, WithId } from '../firestore/collection'
+import { WithId, RawCollection } from '../firestore/collection'
 import { SpeakerData, UserData } from '../firestore/data'
 import { SpeakerPage } from './speakers-view-data'
 
-export const generateSpeakers = (firebaseApp: FirebaseApp) => (_: Request, response: Response) => {
+export const generateSpeakers = (
+    firebaseApp: FirebaseApp,
+    rawCollection: RawCollection
+) => (_: Request, response: Response) => {
     const firestore = firebaseApp.firestore()
-    const rawCollection = firestoreRawCollection(firebaseApp)
 
     const speakersPromise = rawCollection<SpeakerData>('speakers')
     const usersPromise = rawCollection<UserData>('user_profiles')

--- a/functions/src/tracks-view/generate-tracks.ts
+++ b/functions/src/tracks-view/generate-tracks.ts
@@ -1,12 +1,14 @@
 import { Request, Response } from 'express'
 import { FirebaseApp } from '../firebase'
-import { firestoreRawCollection } from '../firestore/collection'
+import { RawCollection } from '../firestore/collection'
 import { TrackData } from '../firestore/data'
 import { Track } from './tracks-view-data'
 
-export const generateTracks = (firebaseApp: FirebaseApp) => (_: Request, response: Response) => {
+export const generateTracks = (
+    firebaseApp: FirebaseApp,
+    rawCollection: RawCollection
+) => (_: Request, response: Response) => {
     const firestore = firebaseApp.firestore()
-    const rawCollection = firestoreRawCollection(firebaseApp)
 
     const tracksPromise = rawCollection<TrackData>('tracks')
 


### PR DESCRIPTION
## Problem

We forgot to get the vendor name from firebase config in `firestoreRawCollection`.

## Solution

`RawCollection` is now a type, and `firestoreRawCollection` an implementation of it. We're now correctly passing the vendor name to it and injecting it as required.

