### PR TITLE
Ensure we "rebase" all references coming via patch

### DIFF
--- a/functions/src/patch/map-fields.ts
+++ b/functions/src/patch/map-fields.ts
@@ -16,30 +16,30 @@ import {
 } from './firestore-api'
 import { mapObject } from '../objects'
 
-export const mapFields = (app: FirebaseApp) => (fields: Fields): { [key: string]: any } => {
-    return mapObject(fields, field => mapField(app)(field))
+export const mapFields = (app: FirebaseApp, vendorName: string) => (fields: Fields): { [key: string]: any } => {
+    return mapObject(fields, field => mapField(app, vendorName)(field))
 }
 
-const mapField = (app: FirebaseApp) => (field: FieldValue): any => {
+const mapField = (app: FirebaseApp, vendorName: string) => (field: FieldValue): any => {
     if (isString(field)) {
         return field.stringValue
     } else if (isBoolean(field)) {
         return field.booleanValue
     } else if (isArray(field)) {
-        return field.arrayValue.values.map(value => mapField(app)(value))
+        return field.arrayValue.values.map(value => mapField(app, vendorName)(value))
     } else if (isInteger(field)) {
         return field.integerValue
     } else if (isDouble(field)) {
         return field.doubleValue
     } else if (isMap(field)) {
-        return mapFields(app)(field.mapValue.fields)
+        return mapFields(app, vendorName)(field.mapValue.fields)
     } else if (isNull(field)) {
         return null
     } else if (isReference(field)) {
         const firestore = app.firestore()
 
         const [, collection, id] = field.referenceValue.split('/')
-        return firestore.collection(collection).doc(id)
+        return firestore.collection('raw_data').doc(vendorName).collection(collection).doc(id)
     } else if (isTimestamp(field)) {
         return new Date(field.timestampValue)
     } else {

--- a/functions/src/patch/patch.ts
+++ b/functions/src/patch/patch.ts
@@ -41,7 +41,7 @@ const patch = (firebaseApp: FirebaseApp, config: PatchConfig) => {
 
         let body: { [field: string]: any }
         try {
-            body = mapFields(firebaseApp)(fields)
+            body = mapFields(firebaseApp, config.vendor_name)(fields)
         } catch (error) {
             res.status(400).send(error.toString())
             return


### PR DESCRIPTION
## Problem

We need to make sure users of patch can only write inside `/raw_data/(vendor)/`

## Solution

Pass in the vendor name to `mapFields()` and `mapField()` that comes from the Functions config, and redirect all references to the resulting collection (e.g., `/raw_data/syx/`).

### Test(s) added

No

### Paired with 

Nobody