### PR TITLE
Remove extra separator from indices names

### DIFF
--- a/functions/src/search/index-contents.ts
+++ b/functions/src/search/index-contents.ts
@@ -15,7 +15,7 @@ export const indexContent =
         )
 
         ensureNotEmpty(algoliaConfig.index_prefix, 'algoliaConfig.index_prefix')
-        const indexPrefix = `${replaceNonWordCharsWithUnderscores(algoliaConfig.index_prefix)}-`
+        const indexPrefix = replaceNonWordCharsWithUnderscores(algoliaConfig.index_prefix)
         Promise.all([
             indexSpeakers(rawCollection, algolia, indexPrefix),
             indexEvents(rawCollection, algolia, indexPrefix)

--- a/functions/src/search/index-events.ts
+++ b/functions/src/search/index-events.ts
@@ -9,7 +9,7 @@ export const indexEvents = (
     algolia: AlgoliaClient,
     indexPrefix: string
 ): Promise<void> => {
-    const eventsIndex = algolia.initIndex(`${indexPrefix}_events`)
+    const eventsIndex = algolia.initIndex(`${indexPrefix}events`)
 
     const eventsPromise = rawCollection<EventData>('events')
     const submissionsPromise = rawCollection<SubmissionData>('submissions')

--- a/functions/src/search/index-events.ts
+++ b/functions/src/search/index-events.ts
@@ -9,7 +9,7 @@ export const indexEvents = (
     algolia: AlgoliaClient,
     indexPrefix: string
 ): Promise<void> => {
-    const eventsIndex = algolia.initIndex(`${indexPrefix}events`)
+    const eventsIndex = algolia.initIndex(`${indexPrefix}-events`)
 
     const eventsPromise = rawCollection<EventData>('events')
     const submissionsPromise = rawCollection<SubmissionData>('submissions')

--- a/functions/src/search/index-speakers.ts
+++ b/functions/src/search/index-speakers.ts
@@ -9,7 +9,7 @@ export const indexSpeakers = (
     algolia: AlgoliaClient,
     indexPrefix: string
 ): Promise<void> => {
-    const speakersIndex = algolia.initIndex(`${indexPrefix}speakers`)
+    const speakersIndex = algolia.initIndex(`${indexPrefix}-speakers`)
 
     const speakersPromise = rawCollection<SpeakerData>('speakers')
     const userProfilesPromise = rawCollection<UserData>('user_profiles')

--- a/functions/src/search/index-speakers.ts
+++ b/functions/src/search/index-speakers.ts
@@ -9,7 +9,7 @@ export const indexSpeakers = (
     algolia: AlgoliaClient,
     indexPrefix: string
 ): Promise<void> => {
-    const speakersIndex = algolia.initIndex(`${indexPrefix}_speakers`)
+    const speakersIndex = algolia.initIndex(`${indexPrefix}speakers`)
 
     const speakersPromise = rawCollection<SpeakerData>('speakers')
     const userProfilesPromise = rawCollection<UserData>('user_profiles')


### PR DESCRIPTION
## Problem

We have one too many separators in the indices names:

![before](https://user-images.githubusercontent.com/153802/37301868-29ee6732-262a-11e8-9fe9-2f2e875816c9.png)

## Solution

Remove the extra separators:

![after](https://user-images.githubusercontent.com/153802/37302056-ba472382-262a-11e8-9882-d06640fa7212.png)

### Test(s) added

No

### Paired with 

Nobody