### PR TITLE
Keep speakers order when generating views

### DIFF
--- a/functions/src/event-details-view/generate-event-details.ts
+++ b/functions/src/event-details-view/generate-event-details.ts
@@ -70,10 +70,8 @@ export const generateEventDetails = (
                 ? levels.find(({ id }) => submissionLevel.id === id)!.name
                 : null
 
-            const eventSpeakers = flattenedSpeakers
-                .filter(({ id }) =>
-                    (submission.speakers || [])
-                        .findIndex(({ id: speakerId }) => speakerId === id) !== -1)
+            const eventSpeakers = (submission.speakers || [])
+                .map(({ id: speakerId }) => flattenedSpeakers.find(({ id }) => id === speakerId)!)
 
             const event: Event = {
                 description: submission.abstract,

--- a/functions/src/schedule-view/generate-schedule.ts
+++ b/functions/src/schedule-view/generate-schedule.ts
@@ -80,10 +80,8 @@ export const generateSchedule = (
                         ? levels.find(({ id }) => submissionLevel.id === id)!.name
                         : null
 
-                    const eventSpeakers = flattenedSpeakers
-                        .filter(({ id }) =>
-                            (submission.speakers || [])
-                                .findIndex(({ id: speakerId }) => speakerId === id) !== -1)
+                    const eventSpeakers = (submission.speakers || [])
+                        .map(({ id: speakerId }) => flattenedSpeakers.find(({ id }) => id === speakerId)!)
 
                     return {
                         description: submission.abstract,


### PR DESCRIPTION
## Problem

Fixes #36 - We need to keep the speakers order when generating the views.

## Solution

Inverted the logic so now we map from the speakers to the events.
