### PR TITLE
Delete previous views

### DIFF
--- a/functions/src/http/http-trigger.ts
+++ b/functions/src/http/http-trigger.ts
@@ -1,0 +1,12 @@
+import { Request, Response } from 'express'
+
+export const httpTrigger = (callback: () => Promise<any>) =>
+    async (_: Request, response: Response) => {
+        try {
+            await callback()
+            response.status(200).send('Success')
+        } catch (error) {
+            console.error(error)
+            response.status(500).send('Something went wrong')
+        }
+    }

--- a/functions/src/main.ts
+++ b/functions/src/main.ts
@@ -11,6 +11,7 @@ import { generateSpeakers } from './speakers-view/generate-speakers'
 import { generateTracks } from './tracks-view/generate-tracks'
 import { fetchTwitter } from './twitter/fetch-twitter'
 import { firestoreRawCollection } from './firestore/collection'
+import { httpTrigger } from './http/http-trigger'
 
 const {
     algolia: algoliaConf,
@@ -24,7 +25,7 @@ const rawCollection = firestoreRawCollection(patchConf.vendor_name, firebaseApp)
 
 export = {
     fetchTwitter: https.onRequest(fetchTwitter(firebaseApp, fetch, twitterConf)),
-    generateEventDetails: https.onRequest(generateEventDetails(firebaseApp, rawCollection)),
+    generateEventDetails: https.onRequest(httpTrigger(generateEventDetails(firebaseApp, rawCollection))),
     generateSchedule: https.onRequest(generateSchedule(firebaseApp, rawCollection)),
     generateSpeakers: https.onRequest(generateSpeakers(firebaseApp, rawCollection)),
     generateTracks: https.onRequest(generateTracks(firebaseApp, rawCollection)),

--- a/functions/src/main.ts
+++ b/functions/src/main.ts
@@ -26,7 +26,7 @@ const rawCollection = firestoreRawCollection(patchConf.vendor_name, firebaseApp)
 export = {
     fetchTwitter: https.onRequest(fetchTwitter(firebaseApp, fetch, twitterConf)),
     generateEventDetails: https.onRequest(httpTrigger(generateEventDetails(firebaseApp, rawCollection))),
-    generateSchedule: https.onRequest(generateSchedule(firebaseApp, rawCollection)),
+    generateSchedule: https.onRequest(httpTrigger(generateSchedule(firebaseApp, rawCollection))),
     generateSpeakers: https.onRequest(generateSpeakers(firebaseApp, rawCollection)),
     generateTracks: https.onRequest(generateTracks(firebaseApp, rawCollection)),
     indexContent: https.onRequest(indexContent(rawCollection, algoliaConf)),

--- a/functions/src/main.ts
+++ b/functions/src/main.ts
@@ -28,7 +28,7 @@ export = {
     generateEventDetails: https.onRequest(httpTrigger(generateEventDetails(firebaseApp, rawCollection))),
     generateSchedule: https.onRequest(httpTrigger(generateSchedule(firebaseApp, rawCollection))),
     generateSpeakers: https.onRequest(httpTrigger(generateSpeakers(firebaseApp, rawCollection))),
-    generateTracks: https.onRequest(generateTracks(firebaseApp, rawCollection)),
+    generateTracks: https.onRequest(httpTrigger(generateTracks(firebaseApp, rawCollection))),
     indexContent: https.onRequest(indexContent(rawCollection, algoliaConf)),
     migrateToFirestore: https.onRequest(migrateToFirestore(firebaseApp)),
     patch: https.onRequest(patch(firebaseApp, patchConf)),

--- a/functions/src/main.ts
+++ b/functions/src/main.ts
@@ -27,7 +27,7 @@ export = {
     fetchTwitter: https.onRequest(fetchTwitter(firebaseApp, fetch, twitterConf)),
     generateEventDetails: https.onRequest(httpTrigger(generateEventDetails(firebaseApp, rawCollection))),
     generateSchedule: https.onRequest(httpTrigger(generateSchedule(firebaseApp, rawCollection))),
-    generateSpeakers: https.onRequest(generateSpeakers(firebaseApp, rawCollection)),
+    generateSpeakers: https.onRequest(httpTrigger(generateSpeakers(firebaseApp, rawCollection))),
     generateTracks: https.onRequest(generateTracks(firebaseApp, rawCollection)),
     indexContent: https.onRequest(indexContent(rawCollection, algoliaConf)),
     migrateToFirestore: https.onRequest(migrateToFirestore(firebaseApp)),

--- a/functions/src/schedule-view/generate-schedule.ts
+++ b/functions/src/schedule-view/generate-schedule.ts
@@ -61,7 +61,7 @@ export const generateSchedule = (
             twitterUsername: speaker.twitter_handle,
         }))
 
-        const schedulePages = days.map(day => {
+        return days.map(day => {
             const eventsOfTheDay = events.filter(event => event.day.id === day.id)
             return {
                 day,
@@ -94,7 +94,7 @@ export const generateSchedule = (
                 })
             }
         })
-
+    }).then(schedulePages => {
         const schedulePagesCollection = firestore.collection('views')
             .doc('schedule')
             .collection('schedule_pages')


### PR DESCRIPTION
## Problem

We didn't delete previous values in our views upon generation, this lead to having dirty data there.

## Solution

All the view generation functions now:

1. Run inside a batch (fail/succeed atomically)
2. Delete previous documents inside the view collection
3. Return a promise and use `httpTrigger` to handle the web request

`3` is there because we want to be able to reuse those inside a function that invokes them all, so that we can regenerate all the views together once the data upload is complete.
