### PR TITLE
Add missing export & import pair to awaitObject

### DIFF
--- a/functions/src/patch/patch.ts
+++ b/functions/src/patch/patch.ts
@@ -4,6 +4,7 @@ import { mapFields } from './map-fields'
 import { mapObject } from '../objects'
 import { squanchyValidators } from './squanchy-validators'
 import { ensureNotEmpty } from '../strings'
+import { awaitObject } from '../promise'
 
 const patch = (firebaseApp: FirebaseApp, config: PatchConfig) => {
     ensureNotEmpty(config.vendor_name, 'config.vendor_name')

--- a/functions/src/promise.ts
+++ b/functions/src/promise.ts
@@ -1,4 +1,4 @@
-const awaitObject = <T>(promisesObject: { [key: string]: Promise<T> })
+export const awaitObject = <T>(promisesObject: { [key: string]: Promise<T> })
     : Promise<{ [key: string]: T }> => {
     return Promise.all(Object.keys(promisesObject).map(key =>
         promisesObject[key].then(value => ({ key, value }))


### PR DESCRIPTION
## Problem

We forgot to `export` the `asyncObject` function, and `import` it where it's used. This means we get a `ReferenceError` when running. For some reason the TS compiler did not flag it tho...

## Solution

Export `awaitObject` and `import` it where it's used.

### Test(s) added

No

### Paired with 

@fourlastor but hey 🤷‍♂️