### PR TITLE
Split talks and other events

### DIFF
--- a/functions/src/firestore/data.ts
+++ b/functions/src/firestore/data.ts
@@ -29,7 +29,6 @@ export interface OtherEventData {
     readonly end_time: Date
     readonly place: Optional<Reference<PlaceData>>
     readonly start_time: Date
-    readonly track: Optional<Reference<TrackData>>
     readonly type: Optional<string>
 }
 

--- a/functions/src/firestore/data.ts
+++ b/functions/src/firestore/data.ts
@@ -23,7 +23,17 @@ export interface UserData {
     readonly profile_pic: string
 }
 
-export interface EventData {
+export interface OtherEventData {
+    readonly title: string
+    readonly day: Reference<DayData>
+    readonly end_time: Date
+    readonly place: Optional<Reference<PlaceData>>
+    readonly start_time: Date
+    readonly track: Optional<Reference<TrackData>>
+    readonly type: Optional<string>
+}
+
+export interface TalkData {
     readonly day: Reference<DayData>
     readonly end_time: Date
     readonly place: Optional<Reference<PlaceData>>

--- a/functions/src/patch/squanchy-validators.ts
+++ b/functions/src/patch/squanchy-validators.ts
@@ -65,8 +65,8 @@ export const squanchyValidators: CollectionsValidator = {
         end_time: [required, isDate],
         place: [isReference],
         start_time: [required, isDate],
-        submission: [required, isReference], // TODO required if type == talk || type == keynote
-        track: [isReference], // TODO required if type == talk
+        submission: [required, isReference],
+        track: [required, isReference],
         type: [required, isString]
     },
     tracks: {

--- a/functions/src/patch/squanchy-validators.ts
+++ b/functions/src/patch/squanchy-validators.ts
@@ -31,7 +31,6 @@ export const squanchyValidators: CollectionsValidator = {
         place: [isReference],
         start_time: [required, isDate],
         title: [required, isString],
-        track: [isReference],
         type: [required, isString]
     },
     places: {

--- a/functions/src/patch/squanchy-validators.ts
+++ b/functions/src/patch/squanchy-validators.ts
@@ -22,17 +22,17 @@ export const squanchyValidators: CollectionsValidator = {
         date: [required, isDate],
         position: [required, isInteger],
     },
-    events: {
+    levels: {
+        name: [required, isString]
+    },
+    other_events: {
         day: [required, isReference],
         end_time: [required, isDate],
         place: [isReference],
         start_time: [required, isDate],
-        submission: [isReference], // TODO required if type == talk || type == keynote
-        track: [isReference], // TODO required if type == talk
+        title: [required, isString],
+        track: [isReference],
         type: [required, isString]
-    },
-    levels: {
-        name: [required, isString]
     },
     places: {
         floor: [isString],
@@ -60,6 +60,15 @@ export const squanchyValidators: CollectionsValidator = {
         notes: [isString],
         speakers: [required, isArray([required, isReference])],
         title: [required, isString]
+    },
+    talks: {
+        day: [required, isReference],
+        end_time: [required, isDate],
+        place: [isReference],
+        start_time: [required, isDate],
+        submission: [required, isReference], // TODO required if type == talk || type == keynote
+        track: [isReference], // TODO required if type == talk
+        type: [required, isString]
     },
     tracks: {
         accent_color: [isString],


### PR DESCRIPTION
## Problem

We need different containers for submitted talks and other events (coffee breaks and stuff like that)

## Solution

We now use 2 collections: `talks` to contain submitted talks, `other_events` to contain the others.

Views are _for now_ generated only from talks, next PR will be to generate views from them + other events.