### PR TITLE
Patch transactions

### DIFF
--- a/functions/src/main.ts
+++ b/functions/src/main.ts
@@ -12,6 +12,7 @@ import { generateTracks } from './tracks-view/generate-tracks'
 import { fetchTwitter } from './twitter/fetch-twitter'
 import { firestoreRawCollection } from './firestore/collection'
 import { httpTrigger } from './http/http-trigger'
+import { startPatch, endPatch } from './patch/transactions'
 
 const {
     algolia: algoliaConf,
@@ -32,4 +33,6 @@ export = {
     indexContent: https.onRequest(httpTrigger(indexContent(rawCollection, algoliaConf))),
     migrateToFirestore: https.onRequest(migrateToFirestore(firebaseApp)),
     patch: https.onRequest(patch(firebaseApp, patchConf)),
+    startPatch: https.onRequest(startPatch(firebaseApp, patchConf)),
+    endPatch: https.onRequest(endPatch(firebaseApp, rawCollection, patchConf, algoliaConf))
 }

--- a/functions/src/patch/authorize.ts
+++ b/functions/src/patch/authorize.ts
@@ -1,0 +1,19 @@
+import * as express from 'express'
+
+export const authorize = (appToken: string): express.RequestHandler => (req, res, next) => {
+    const authorization = req.headers.authorization as string
+
+    if (!authorization || !authorization.startsWith('Bearer ')) {
+        res.status(403).send('Unauthorized')
+        return
+    }
+
+    const token = authorization.substr('Bearer '.length)
+
+    if (token !== appToken) {
+        res.status(403).send('Unauthorized')
+        return
+    }
+
+    return next()
+}

--- a/functions/src/patch/patch.ts
+++ b/functions/src/patch/patch.ts
@@ -5,29 +5,14 @@ import { mapObject } from '../objects'
 import { squanchyValidators } from './squanchy-validators'
 import { ensureNotEmpty } from '../strings'
 import { awaitObject } from '../promise'
+import { authorize } from './authorize'
 
 const patch = (firebaseApp: FirebaseApp, config: PatchConfig) => {
     ensureNotEmpty(config.vendor_name, 'config.vendor_name')
 
     const expressApp = express()
 
-    expressApp.use((req, res, next) => {
-        const authorization = req.headers.authorization as string
-
-        if (!authorization || !authorization.startsWith('Bearer ')) {
-            res.status(403).send('Unauthorized')
-            return
-        }
-
-        const token = authorization.substr('Bearer '.length)
-
-        if (token !== config.app_token) {
-            res.status(403).send('Unauthorized')
-            return
-        }
-
-        return next()
-    })
+    expressApp.use(authorize(config.app_token))
 
     expressApp.patch('/:collection/:id', (req, res) => {
         const collection = req.params.collection as string

--- a/functions/src/patch/transactions.ts
+++ b/functions/src/patch/transactions.ts
@@ -20,13 +20,14 @@ export const startPatch = (firebaseApp: FirebaseApp, config: PatchConfig) => {
         httpTrigger(
             () => {
                 const firestore = firebaseApp.firestore()
-
+                const allowed: string[] = req.body.collections || []
                 return firestore
                     .collection('raw_data')
                     .doc(config.vendor_name)
                     .getCollections()
                     .then(collections => {
-                        return Promise.all(collections.map(collection => {
+                        const allowedCollections = collections.filter(it => allowed.indexOf(it.id) !== -1)
+                        return Promise.all(allowedCollections.map(collection => {
                             return collection.get()
                                 .then(snapshot => {
                                     const batch = firestore.batch()

--- a/functions/src/patch/transactions.ts
+++ b/functions/src/patch/transactions.ts
@@ -1,0 +1,52 @@
+import * as express from 'express'
+import { FirebaseApp } from '../firebase'
+import { RawCollection } from '../firestore/collection'
+
+import { generateSchedule } from '../schedule-view/generate-schedule'
+import { generateEventDetails } from '../event-details-view/generate-event-details'
+import { generateSpeakers } from '../speakers-view/generate-speakers'
+import { generateTracks } from '../tracks-view/generate-tracks'
+import { indexContent } from '../index-contents/index-contents'
+import { httpTrigger } from '../http/http-trigger'
+import { AlgoliaConfig } from '../index-contents/config'
+import { authorize } from './authorize'
+
+export const startPatch = (firebaseApp: FirebaseApp, config: PatchConfig) => {
+    const expressApp = express()
+
+    expressApp.use(authorize(config.app_token))
+
+    expressApp.get('*', (req, res) => {
+        httpTrigger(
+            () => firebaseApp.firestore()
+                .collection('raw_data')
+                .doc(config.vendor_name)
+                .delete()
+        )(req, res)
+    })
+
+    return expressApp
+}
+
+export const endPatch = (
+    firebaseApp: FirebaseApp,
+    collection: RawCollection,
+    config: PatchConfig,
+    algoliaConfig: AlgoliaConfig
+) => {
+    const expressApp = express()
+
+    expressApp.use(authorize(config.app_token))
+
+    expressApp.get('*', (req, res) => {
+        httpTrigger(() => Promise.all([
+            generateSchedule(firebaseApp, collection)(),
+            generateEventDetails(firebaseApp, collection)(),
+            generateSpeakers(firebaseApp, collection)(),
+            generateTracks(firebaseApp, collection)(),
+            indexContent(collection, algoliaConfig)()
+        ]))(req, res)
+    })
+
+    return expressApp
+}

--- a/functions/src/patch/transactions.ts
+++ b/functions/src/patch/transactions.ts
@@ -16,7 +16,7 @@ export const startPatch = (firebaseApp: FirebaseApp, config: PatchConfig) => {
 
     expressApp.use(authorize(config.app_token))
 
-    expressApp.get('*', (req, res) => {
+    expressApp.post('*', (req, res) => {
         httpTrigger(
             () => firebaseApp.firestore()
                 .collection('raw_data')
@@ -38,7 +38,7 @@ export const endPatch = (
 
     expressApp.use(authorize(config.app_token))
 
-    expressApp.get('*', (req, res) => {
+    expressApp.post('*', (req, res) => {
         httpTrigger(() => Promise.all([
             generateSchedule(firebaseApp, collection)(),
             generateEventDetails(firebaseApp, collection)(),

--- a/functions/tslint.json
+++ b/functions/tslint.json
@@ -8,6 +8,7 @@
         "arrow-parens": [true, "ban-single-arg-parens"],
         "no-console": [false],
         "array-type": [true, "array"],
-        "ordered-imports": [false]
+        "ordered-imports": [false],
+        "object-literal-sort-keys": [false]
     }
 }


### PR DESCRIPTION
## Problem

We need a mechanism to signal when a series of patches are going to take place (to delete previously stored data), and when they're done (to regenerate the views/search indexes)

## Solution

`startPatch` will delete all the data (we need to delete every doc in every collection under our `raw_data` doc, I tried deleting the parent doc and it doesn't work).

`endPatch` will fire up the indexing/regeneration of views.

Both endpoints are protected with the same app token used in `patch`.