### PR TITLE
Filter out speakers without talks from search indices and from speakers view

### DIFF
--- a/functions/src/index-contents/index-speakers.ts
+++ b/functions/src/index-contents/index-speakers.ts
@@ -1,7 +1,7 @@
 import { AlgoliaClient } from 'algoliasearch'
 
 import { WithId, RawCollection } from '../firestore/collection'
-import { SpeakerData, UserData } from '../firestore/data'
+import { SpeakerData, UserData, SubmissionData, TalkData } from '../firestore/data'
 import { SpeakerRecord } from './records'
 import { clearIndex } from './clear-index'
 
@@ -14,13 +14,37 @@ export const indexSpeakers = (
 
     const speakersPromise = rawCollection<SpeakerData>('speakers')
     const userProfilesPromise = rawCollection<UserData>('user_profiles')
+    const submissionsPromise = rawCollection<SubmissionData>('submissions')
+    const talksPromise = rawCollection<TalkData>('talks')
 
-    return Promise.all([speakersPromise, userProfilesPromise])
+    return Promise.all([speakersPromise, userProfilesPromise, submissionsPromise, talksPromise])
+        .then(([speakers, userProfiles, submissions, talks]) => {
+            return filterOutSpeakersWithNoTalks(speakers, userProfiles, submissions, talks)
+        })
         .then(([speakers, userProfiles]) => toSpeakerRecords(speakers, userProfiles))
         .then(speakers => {
             return clearIndex(speakersIndex)
-                .then(() =>  speakersIndex.addObjects(speakers))
+                .then(() => speakersIndex.addObjects(speakers))
         })
+}
+
+const filterOutSpeakersWithNoTalks = (
+    speakers: WithId<SpeakerData>[],
+    userProfiles: WithId<UserData>[],
+    submissions: WithId<SubmissionData>[],
+    talks: WithId<TalkData>[]
+): [WithId<SpeakerData>[], WithId<UserData>[]] => {
+    const talkSubmissions = submissions.filter(submission => {
+        return talks.some(talk => talk.submission.id === submission.id)
+    })
+
+    const speakersWithTalks = speakers.filter(speaker => {
+        return talkSubmissions.some(submission => {
+            return submission.speakers.some(submissionSpeaker => submissionSpeaker.id === speaker.id)
+        })
+    })
+
+    return [speakersWithTalks, userProfiles]
 }
 
 const toSpeakerRecords = (speakers: WithId<SpeakerData>[], userProfiles: WithId<UserData>[]): SpeakerRecord[] => {


### PR DESCRIPTION
## Problem

Seems that Syx doesn't only send us the speakers that have talks, they send them _all_. This means we have all CfP users showing up in the `speakers` view and in search results, which is obviously wrong. Amongst those there are some frankensteins, too, that have the speaker data for a speaker but point to an unrelated user profile.

## Solution

Filter out speakers that don't have talks, both when indexing speakers for Algolia and when creating the speakers view.

### Test(s) added 

No

### Paired with 

Nobody