### PR TITLE
Remove request

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -17,8 +17,7 @@
     "express": "^4.16.2",
     "firebase-admin": "~5.11.0",
     "firebase-functions": "^1.0.0",
-    "node-fetch": "^1.7.3",
-    "request": "2.34"
+    "node-fetch": "^1.7.3"
   },
   "private": true,
   "devDependencies": {

--- a/functions/package.json
+++ b/functions/package.json
@@ -17,7 +17,7 @@
     "express": "^4.16.2",
     "firebase-admin": "~6.0.0",
     "firebase-functions": "^2.1.0",
-    "node-fetch": "^1.7.3",
+    "node-fetch": "^1.7.3"
   },
   "private": true,
   "devDependencies": {


### PR DESCRIPTION
## Problem

There's a security alert about having `request` version lower than `2.68.0`.

## Solution

Remove the package as we're not using it
