### PR TITLE
Bug hunt

### DIFF
--- a/functions/src/patch/map-fields.ts
+++ b/functions/src/patch/map-fields.ts
@@ -38,7 +38,7 @@ const mapField = (app: FirebaseApp, vendorName: string) => (field: FieldValue): 
     } else if (isReference(field)) {
         const firestore = app.firestore()
 
-        const [, collection, id] = field.referenceValue.split('/')
+        const [id, collection] = field.referenceValue.split('/').reverse()
         return firestore.collection('raw_data').doc(vendorName).collection(collection).doc(id)
     } else if (isTimestamp(field)) {
         return new Date(field.timestampValue)

--- a/functions/src/patch/patch.ts
+++ b/functions/src/patch/patch.ts
@@ -17,7 +17,7 @@ const patch = (firebaseApp: FirebaseApp, config: PatchConfig) => {
     expressApp.patch('/:collection/:id', (req, res) => {
         const collection = req.params.collection as string
         const id = req.params.id as string
-        const { fields } = req.body
+        const fields = req.body.fields || {}
 
         const validators = squanchyValidators[collection]
         if (!validators) {
@@ -29,6 +29,7 @@ const patch = (firebaseApp: FirebaseApp, config: PatchConfig) => {
         try {
             body = mapFields(firebaseApp, config.vendor_name)(fields)
         } catch (error) {
+            console.error(error)
             res.status(400).send(error.toString())
             return
         }


### PR DESCRIPTION
## Problem

Some bugs encountered while using `patch`

## Solution

#### `[, a, b]` won't take the last 2 elements of an array.
For example:
```javascript
const [, a, b] = [1, 2]
a == 2
b == undefined
```
Using `Array#reverse` and `[b, a]` does the trick.

#### Support missing fields object in `patch`
Now it will default to an empty object, and possibly fail with an error message. Before it would fail with a cryptic message.
