### PR TITLE
Update to node 8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:latest-browsers
+      - image: circleci/node:8
 
     working_directory: ~/project/functions
 

--- a/functions/package.json
+++ b/functions/package.json
@@ -40,5 +40,6 @@
       "json",
       "node"
     ]
-  }
+  },
+  "engines": {"node": "8"}
 }


### PR DESCRIPTION
## Problem

> April 22, 2020: Node.js 6 will be decommissioned on Cloud Functions. You will no longer be able to create new functions or update existing functions that use Node.js 6. Functions using Node.js 6 may be disabled after this date.

## Solution

Update the runtime to NodeJS 8

https://cloud.google.com/functions/docs/migrating/nodejs-runtimes

### Changes introduced in the Node.js 8 runtime

> The signature for background functions changed between the Node.js 6 and the Node.js 8 runtimes.

We don't have any background function (i.e., events from firestore db/pubsub/login/logout)

## Why not Node 10?

https://cloud.google.com/functions/docs/concepts/nodejs-10-runtime

> This is a **beta** release of the Node.js 10 runtime for Google Cloud Functions. This feature might be changed in backward-incompatible ways and is not subject to any SLA or deprecation policy.

We don't like beta 😁 